### PR TITLE
feat: 세차장 정보 수정 페이지 파일 세팅 & chore: 배포용 파일 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM krmp-d2hub-idock.9rum.cc/goorm/node:16 AS build
+WORKDIR /usr/src/app
+COPY /package*.json ./
+RUN npm ci
+COPY / ./
+RUN npm run build
+
+# Run stage
+FROM krmp-d2hub-idock.9rum.cc/goorm/node:16
+WORKDIR /usr/src/app
+COPY --from=build /usr/src/app/dist ./dist
+RUN npm install -g serve
+EXPOSE 3000
+CMD ["serve", "-s", "dist"]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          # 여러분의 image 주소를 입력해주세요.
+          image: krmp-d2hub-idock.9rum.cc/dev-test/repo_d1e7fba0706d

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  labels:
+    app.kubernetes.io/managed-by: kargocd
+  name: krampoline
+  namespace: default
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: frontend
+              servicePort: 3000
+              path: /
+              pathType: Prefix

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: krampoline
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app: frontend

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import SalesManagementPage from "./pages/SalesManagementPage";
 import MainLayout from "./layouts/MainLayout";
 import CarwashManagementPage from "./pages/CarwashManagementPage";
 import CarwashItemManagementPage from "./pages/CarwashItemManagementPage";
+import CarwashDetailEditingPage from "./pages/CarwashDetailEditingPage";
 
 const App = () => {
   return (
@@ -20,6 +21,9 @@ const App = () => {
             <Route
               path="/manage/item"
               element={<CarwashItemManagementPage />}></Route>
+            <Route
+              path="/manage/item/edit"
+              element={<CarwashDetailEditingPage />}></Route>
           </Route>
           <Route path="/login" element={<LoginPage />}></Route>
           <Route path="/signup" element={<SignupPage />}></Route>

--- a/src/apis/carwashes.js
+++ b/src/apis/carwashes.js
@@ -5,15 +5,14 @@ export const getCarwashes = () => {
 };
 
 export const getCarwashesDetails = (carwash_id) => {
-  return instance.get(`/owner/${carwash_id}/carwashes`);
+  return instance.get(`/owner/carwashes/${carwash_id}/details`);
 };
 
 export const putCarwashesDetails = (carwash_id, data) => {
-  return instance.put(`/owner/${carwash_id}/carwashes`, data);
+  return instance.put(`/owner/carwashes/${carwash_id}/details`, data);
 };
 
 export const postRegister = (data) => {
-  console.log(data);
   return instance.post("/owner/carwashes/register", data);
 };
 

--- a/src/components/organisms/RegisterForm.jsx
+++ b/src/components/organisms/RegisterForm.jsx
@@ -2,15 +2,12 @@ import { useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import TextInput from "../atoms/TextInput";
 import Button from "../atoms/Button";
-import Box from "../atoms/Box";
 import KeyPointSelector from "../molecules/KeyPointSelector";
 import Checkbox from "../atoms/CheckBox";
 import DaumPostcode from "react-daum-postcode";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { postRegister } from "../../apis/carwashes";
 
 /**
  * RegisterForm
@@ -24,13 +21,20 @@ import { postRegister } from "../../apis/carwashes";
  * @todo 복잡한 로직은 컴포넌트로 분리 필요(운영시간, 매장사진, 키포인트)
  * @todo isSubmitting 상태에 따라 입점신청 버튼 스타일 변경 필요
  */
-const RegisterForm = () => {
-  const mutation = useMutation({
-    mutationFn: (data) => {
-      postRegister(data);
-    },
-  });
-
+const RegisterForm = ({
+  carwashName,
+  carwashAddress,
+  carwashTel,
+  pricePer30min,
+  weekdayOpenTime,
+  weekdayCloseTime,
+  weekendOpenTime,
+  weekendCloseTime,
+  carwashImage,
+  keypoint,
+  carwashDescription,
+  mutation,
+}) => {
   const navigate = useNavigate();
 
   const {
@@ -121,370 +125,367 @@ const RegisterForm = () => {
   ];
 
   return (
-    <Box className="grid gap-8 p-14">
-      {/*제목 텍스트*/}
-      <div className="grid gap-4 text-center">
-        <h1 className="text-3xl font-bold">입점을 환영합니다!</h1>
-        <div className="text-gray-500">아래 정보들을 입력해주세요.</div>
-      </div>
-
-      <form
-        className="grid gap-8"
-        onSubmit={handleSubmit((data) => {
-          mutation.mutate(data, {
-            onSuccess: () => {
-              navigate("/");
-            },
-            onError: (error) => {
-              // TODO: 입점신청 실패 시 에러 처리 필요
-              console.log(error);
-            },
-          });
-        })}>
-        {/* Wrapper */}
-        <div className="flex gap-8">
-          {/* 왼쪽 영역 */}
-          <section className="grid gap-4">
-            {/* 매장명 */}
-            <div className="grid gap-2">
-              <div className="flex items-center justify-between">
-                <label htmlFor="carwashName" className="text-gray-700">
-                  매장명
-                </label>
-                {errors.carwashName && (
-                  <small className="text-red-500" role="alert">
-                    {errors.carwashName.message}
-                  </small>
-                )}
-              </div>
-              <TextInput
-                id="carwashName"
-                type="text"
-                placeholder="○○세차장"
-                {...register("carwashName", {
-                  required: MESSAGES.common.required,
-                })}
-              />
-            </div>
-            {/* 주소 */}
-            <div className="grid gap-2">
-              <div className="flex items-center justify-between">
-                <label htmlFor="carwashAddress" className="text-gray-700">
-                  주소
-                </label>
-                {errors.carwashAddress && (
-                  <small className="text-red-500" role="alert">
-                    {errors.carwashAddress.message}
-                  </small>
-                )}
-              </div>
-              <div className="relative flex gap-4 w-96">
-                <TextInput
-                  id="carwashAddress"
-                  type="text"
-                  placeholder="주소"
-                  disabled={true}
-                  {...register("carwashAddress", {
-                    required: MESSAGES.common.required,
-                  })}
-                />
-                <Button
-                  onClick={() => {
-                    setOpenPostcode((current) => !current);
-                  }}
-                  className="shrink-0"
-                  style="small">
-                  주소검색
-                </Button>
-                {openPostcode && (
-                  <div className="absolute z-50 overflow-auto bg-white border w-96 rounded-xl">
-                    <div className="flex items-center justify-between p-4 bg-gray-100 border-b">
-                      <div>주소검색</div>
-                      <Button
-                        className="text-xl"
-                        onClick={() => {
-                          setOpenPostcode(false);
-                        }}>
-                        ✕
-                      </Button>
-                    </div>
-                    <DaumPostcode
-                      onComplete={(data) => {
-                        setValue("carwashAddress", data.address);
-                        setOpenPostcode(false);
-                      }}
-                      autoClose={false}
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
-            {/* 전화번호 */}
-            <div className="grid gap-2">
-              <div className="flex items-center justify-between">
-                <label htmlFor="carwashTel" className="text-gray-700">
-                  전화번호
-                </label>
-                {errors.carwashTel && (
-                  <small className="text-red-500" role="alert">
-                    {errors.carwashTel.message}
-                  </small>
-                )}
-              </div>
-              <TextInput
-                id="carwashTel"
-                type="tel"
-                placeholder="전화번호"
-                {...register("carwashTel", {
-                  required: MESSAGES.common.required,
-                })}
-              />
-            </div>
-            {/* 30분 당 금액 */}
-            <div className="grid gap-2">
-              <div className="flex items-center justify-between">
-                <label htmlFor="pricePer30min" className="text-gray-700">
-                  30분 당 금액
-                </label>
-                {errors.pricePer30min && (
-                  <small className="text-red-500" role="alert">
-                    {errors.pricePer30min.message}
-                  </small>
-                )}
-              </div>
-              <TextInput
-                id="pricePer30min"
-                type="number"
-                placeholder="30분 당 금액"
-                {...register("pricePer30min", {
-                  required: MESSAGES.common.required,
-                })}
-              />
-            </div>
-
-            {/* 영업시간 */}
-            <div className="grid gap-2">
-              <div className="flex justify-between w-96">
-                <label className="text-gray-700">영업시간</label>
-                {(errors.weekdayOpenTime ||
-                  errors.weekdayCloseTime ||
-                  errors.weekendOpenTime ||
-                  errors.weekendCloseTime) && (
-                  <small className="text-red-500" role="alert">
-                    필수 입력입니다.
-                  </small>
-                )}
-                <Checkbox
-                  onChange={(e) => {
-                    if (e.target.checked) {
-                      setWeekday24hrs(true);
-                      setValue("weekdayOpenTime", new Date(0, 0, 0, 0, 0));
-                      setValue("weekdayCloseTime", new Date(0, 0, 0, 23, 59));
-                    } else {
-                      setWeekday24hrs(false);
-                    }
-                  }}>
-                  24시간 영업
-                </Checkbox>
-              </div>
-              <div className="flex items-center gap-2 w-96">
-                <label className="text-gray-700 shrink-0">평일</label>
-                <Controller
-                  control={control}
-                  name="weekdayOpenTime"
-                  rules={{ required: MESSAGES.common.required }}
-                  render={({ field }) => (
-                    <DatePicker
-                      className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
-                      dateFormat="h:mm aa"
-                      onChange={(date) => field.onChange(date)}
-                      selected={field.value}
-                      showTimeSelect
-                      showTimeSelectOnly
-                      timeIntervals={30}
-                      timeCaption="시작 시간"
-                      disabled={weekday24hrs}
-                    />
-                  )}
-                />
-                {"~"}
-                <Controller
-                  control={control}
-                  name="weekdayCloseTime"
-                  rules={{ required: MESSAGES.common.required }}
-                  render={({ field }) => (
-                    <DatePicker
-                      className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
-                      dateFormat="h:mm aa"
-                      onChange={(date) => field.onChange(date)}
-                      selected={field.value}
-                      showTimeSelect
-                      showTimeSelectOnly
-                      timeIntervals={30}
-                      timeCaption="종료 시간"
-                      disabled={weekday24hrs}
-                    />
-                  )}
-                />
-              </div>
-              <div className="flex justify-end w-96">
-                <Checkbox
-                  onChange={(e) => {
-                    if (e.target.checked) {
-                      setWeekend24hrs(true);
-                      setValue("weekendOpenTime", new Date(0, 0, 0, 0, 0));
-                      setValue("weekendCloseTime", new Date(0, 0, 0, 23, 59));
-                    } else {
-                      setWeekend24hrs(false);
-                    }
-                  }}>
-                  24시간 영업
-                </Checkbox>
-              </div>
-              <div className="flex items-center gap-2 w-96">
-                <label className="text-gray-700 shrink-0">주말</label>
-                <Controller
-                  control={control}
-                  name="weekendOpenTime"
-                  rules={{ required: MESSAGES.common.required }}
-                  render={({ field }) => (
-                    <DatePicker
-                      className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
-                      dateFormat="h:mm aa"
-                      onChange={(date) => field.onChange(date)}
-                      selected={field.value}
-                      showTimeSelect
-                      showTimeSelectOnly
-                      timeIntervals={30}
-                      timeCaption="시작 시간"
-                      disabled={weekend24hrs}
-                    />
-                  )}
-                />
-                {"~"}
-                <Controller
-                  control={control}
-                  name="weekendCloseTime"
-                  rules={{ required: MESSAGES.common.required }}
-                  render={({ field }) => (
-                    <DatePicker
-                      className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
-                      dateFormat="h:mm aa"
-                      onChange={(date) => field.onChange(date)}
-                      selected={field.value}
-                      showTimeSelect
-                      showTimeSelectOnly
-                      timeIntervals={30}
-                      timeCaption="종료 시간"
-                      disabled={weekend24hrs}
-                    />
-                  )}
-                />
-              </div>
-            </div>
-          </section>
-
-          {/* 오른쪽 영역 */}
-          <section className="grid gap-4">
-            {/*매장 사진*/}
-            <div className="grid gap-2">
-              <label
-                htmlFor="carwashImage"
-                className="flex justify-between text-gray-700">
-                <div>매장사진</div>
-
-                <Button
-                  onClick={() => {
-                    document.getElementById("carwashImage").click();
-                  }}
-                  style="addPhoto">
-                  + 추가
-                </Button>
+    <form
+      className="grid gap-8"
+      onSubmit={handleSubmit((data) => {
+        mutation.mutate(data, {
+          onSuccess: () => {
+            navigate("/");
+          },
+          onError: (error) => {
+            // TODO: 입점신청 실패 시 에러 처리 필요
+            console.log(error);
+          },
+        });
+      })}>
+      {/* Wrapper */}
+      <div className="flex gap-8">
+        {/* 왼쪽 영역 */}
+        <section className="grid gap-4">
+          {/* 매장명 */}
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between">
+              <label htmlFor="carwashName" className="text-gray-700">
+                매장명
               </label>
-              <input
-                type="file"
-                accept="image/*"
-                id="carwashImage"
-                hidden
-                {...register("carwashImage", {
-                  onChange: handleChangeData,
+              {errors.carwashName && (
+                <small className="text-red-500" role="alert">
+                  {errors.carwashName.message}
+                </small>
+              )}
+            </div>
+            <TextInput
+              id="carwashName"
+              type="text"
+              defaultValue={carwashName}
+              placeholder="○○세차장"
+              {...register("carwashName", {
+                required: MESSAGES.common.required,
+              })}
+            />
+          </div>
+          {/* 주소 */}
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between">
+              <label htmlFor="carwashAddress" className="text-gray-700">
+                주소
+              </label>
+              {errors.carwashAddress && (
+                <small className="text-red-500" role="alert">
+                  {errors.carwashAddress.message}
+                </small>
+              )}
+            </div>
+            <div className="relative flex gap-4 w-96">
+              <TextInput
+                id="carwashAddress"
+                type="text"
+                defaultValue={carwashAddress}
+                placeholder="주소"
+                disabled={true}
+                {...register("carwashAddress", {
+                  required: MESSAGES.common.required,
                 })}
               />
-              <div className="flex gap-4 p-4 overflow-x-auto overflow-y-hidden bg-gray-100 border border-gray-300 outline-none w-96 rounded-xl h-28">
-                {imagePreview
-                  ? imagePreview.map((item, index) => {
-                      return (
-                        <div
-                          key={index}
-                          className="relative w-20 h-20 overflow-auto shrink-0 rounded-xl"
-                          onClick={() => {
-                            handleClickImage(index);
-                          }}>
-                          <img
-                            className="absolute object-cover w-full h-full"
-                            src={item}
-                            alt={`미리보기 ${index}}`}
-                          />
-                          {index === 0 ? (
-                            <div className="absolute bottom-0 w-full p-1 text-xs text-center text-white bg-primary font-semobold">
-                              프로필
-                            </div>
-                          ) : null}
-                          <Button
-                            style="deletePhoto"
-                            onClick={(e) => handleClickDelete(e, index)}
-                            className="absolute top-1 right-1">
-                            ✕
-                          </Button>
-                        </div>
-                      );
-                    })
-                  : null}
-              </div>
+              <Button
+                onClick={() => {
+                  setOpenPostcode((current) => !current);
+                }}
+                className="shrink-0"
+                style="small">
+                주소검색
+              </Button>
+              {openPostcode && (
+                <div className="absolute z-50 overflow-auto bg-white border w-96 rounded-xl">
+                  <div className="flex items-center justify-between p-4 bg-gray-100 border-b">
+                    <div>주소검색</div>
+                    <Button
+                      className="text-xl"
+                      onClick={() => {
+                        setOpenPostcode(false);
+                      }}>
+                      ✕
+                    </Button>
+                  </div>
+                  <DaumPostcode
+                    onComplete={(data) => {
+                      setValue("carwashAddress", data.address);
+                      setOpenPostcode(false);
+                    }}
+                    autoClose={false}
+                  />
+                </div>
+              )}
             </div>
-            {/* 키포인트 */}
-            <div className="grid gap-2">
-              <label className="text-gray-700">키포인트</label>
-              {/* <div className="p-4 bg-gray-100 border border-gray-300 outline-none w-96 rounded-xl">
+          </div>
+          {/* 전화번호 */}
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between">
+              <label htmlFor="carwashTel" className="text-gray-700">
+                전화번호
+              </label>
+              {errors.carwashTel && (
+                <small className="text-red-500" role="alert">
+                  {errors.carwashTel.message}
+                </small>
+              )}
+            </div>
+            <TextInput
+              id="carwashTel"
+              type="tel"
+              defaultValue={carwashTel}
+              placeholder="전화번호"
+              {...register("carwashTel", {
+                required: MESSAGES.common.required,
+              })}
+            />
+          </div>
+          {/* 30분 당 금액 */}
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between">
+              <label htmlFor="pricePer30min" className="text-gray-700">
+                30분 당 금액
+              </label>
+              {errors.pricePer30min && (
+                <small className="text-red-500" role="alert">
+                  {errors.pricePer30min.message}
+                </small>
+              )}
+            </div>
+            <TextInput
+              id="pricePer30min"
+              type="number"
+              defaultValue={pricePer30min}
+              placeholder="30분 당 금액"
+              {...register("pricePer30min", {
+                required: MESSAGES.common.required,
+              })}
+            />
+          </div>
+
+          {/* 영업시간 */}
+          <div className="grid gap-2">
+            <div className="flex justify-between w-96">
+              <label className="text-gray-700">영업시간</label>
+              {(errors.weekdayOpenTime ||
+                errors.weekdayCloseTime ||
+                errors.weekendOpenTime ||
+                errors.weekendCloseTime) && (
+                <small className="text-red-500" role="alert">
+                  필수 입력입니다.
+                </small>
+              )}
+              <Checkbox
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setWeekday24hrs(true);
+                    setValue("weekdayOpenTime", new Date(0, 0, 0, 0, 0));
+                    setValue("weekdayCloseTime", new Date(0, 0, 0, 23, 59));
+                  } else {
+                    setWeekday24hrs(false);
+                  }
+                }}>
+                24시간 영업
+              </Checkbox>
+            </div>
+            <div className="flex items-center gap-2 w-96">
+              <label className="text-gray-700 shrink-0">평일</label>
+              <Controller
+                control={control}
+                name="weekdayOpenTime"
+                rules={{ required: MESSAGES.common.required }}
+                render={({ field }) => (
+                  <DatePicker
+                    className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
+                    dateFormat="h:mm aa"
+                    onChange={(date) => field.onChange(date)}
+                    selected={field.value}
+                    showTimeSelect
+                    showTimeSelectOnly
+                    timeIntervals={30}
+                    timeCaption="시작 시간"
+                    disabled={weekday24hrs}
+                  />
+                )}
+              />
+              {"~"}
+              <Controller
+                control={control}
+                name="weekdayCloseTime"
+                rules={{ required: MESSAGES.common.required }}
+                render={({ field }) => (
+                  <DatePicker
+                    className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
+                    dateFormat="h:mm aa"
+                    onChange={(date) => field.onChange(date)}
+                    selected={field.value}
+                    showTimeSelect
+                    showTimeSelectOnly
+                    timeIntervals={30}
+                    timeCaption="종료 시간"
+                    disabled={weekday24hrs}
+                  />
+                )}
+              />
+            </div>
+            <div className="flex justify-end w-96">
+              <Checkbox
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setWeekend24hrs(true);
+                    setValue("weekendOpenTime", new Date(0, 0, 0, 0, 0));
+                    setValue("weekendCloseTime", new Date(0, 0, 0, 23, 59));
+                  } else {
+                    setWeekend24hrs(false);
+                  }
+                }}>
+                24시간 영업
+              </Checkbox>
+            </div>
+            <div className="flex items-center gap-2 w-96">
+              <label className="text-gray-700 shrink-0">주말</label>
+              <Controller
+                control={control}
+                name="weekendOpenTime"
+                rules={{ required: MESSAGES.common.required }}
+                render={({ field }) => (
+                  <DatePicker
+                    className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
+                    dateFormat="h:mm aa"
+                    onChange={(date) => field.onChange(date)}
+                    selected={field.value}
+                    showTimeSelect
+                    showTimeSelectOnly
+                    timeIntervals={30}
+                    timeCaption="시작 시간"
+                    disabled={weekend24hrs}
+                  />
+                )}
+              />
+              {"~"}
+              <Controller
+                control={control}
+                name="weekendCloseTime"
+                rules={{ required: MESSAGES.common.required }}
+                render={({ field }) => (
+                  <DatePicker
+                    className="w-40 p-4 bg-gray-100 border border-gray-300 outline-none h-14 rounded-xl disabled:opacity-30"
+                    dateFormat="h:mm aa"
+                    onChange={(date) => field.onChange(date)}
+                    selected={field.value}
+                    showTimeSelect
+                    showTimeSelectOnly
+                    timeIntervals={30}
+                    timeCaption="종료 시간"
+                    disabled={weekend24hrs}
+                  />
+                )}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* 오른쪽 영역 */}
+        <section className="grid gap-4">
+          {/*매장 사진*/}
+          <div className="grid gap-2">
+            <label
+              htmlFor="carwashImage"
+              className="flex justify-between text-gray-700">
+              <div>매장사진</div>
+
+              <Button
+                onClick={() => {
+                  document.getElementById("carwashImage").click();
+                }}
+                style="addPhoto">
+                + 추가
+              </Button>
+            </label>
+            <input
+              type="file"
+              accept="image/*"
+              id="carwashImage"
+              hidden
+              {...register("carwashImage", {
+                onChange: handleChangeData,
+              })}
+            />
+            <div className="flex gap-4 p-4 overflow-x-auto overflow-y-hidden bg-gray-100 border border-gray-300 outline-none w-96 rounded-xl h-28">
+              {imagePreview
+                ? imagePreview.map((item, index) => {
+                    return (
+                      <div
+                        key={index}
+                        className="relative w-20 h-20 overflow-auto shrink-0 rounded-xl"
+                        onClick={() => {
+                          handleClickImage(index);
+                        }}>
+                        <img
+                          className="absolute object-cover w-full h-full"
+                          src={item}
+                          alt={`미리보기 ${index}}`}
+                        />
+                        {index === 0 ? (
+                          <div className="absolute bottom-0 w-full p-1 text-xs text-center text-white bg-primary font-semobold">
+                            프로필
+                          </div>
+                        ) : null}
+                        <Button
+                          style="deletePhoto"
+                          onClick={(e) => handleClickDelete(e, index)}
+                          className="absolute top-1 right-1">
+                          ✕
+                        </Button>
+                      </div>
+                    );
+                  })
+                : null}
+            </div>
+          </div>
+          {/* 키포인트 */}
+          <div className="grid gap-2">
+            <label className="text-gray-700">키포인트</label>
+            {/* <div className="p-4 bg-gray-100 border border-gray-300 outline-none w-96 rounded-xl">
                 <div className="flex flex-wrap justify-center gap-4"></div>
               </div> */}
-              <KeyPointSelector
-                pointLabels={pointLabels}
-                control={control}
-                name="keypoint"
-              />
+            <KeyPointSelector
+              pointLabels={pointLabels}
+              control={control}
+              name="keypoint"
+            />
+          </div>
+          {/* 매장 설명 */}
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between">
+              <label htmlFor="carwashDescription" className="text-gray-700">
+                매장 설명
+              </label>
+              {errors.carwashDescription && (
+                <small className="text-red-500" role="alert">
+                  {errors.carwashDescription.message}
+                </small>
+              )}
             </div>
-            {/* 매장 설명 */}
-            <div className="grid gap-2">
-              <div className="flex items-center justify-between">
-                <label htmlFor="carwashDescription" className="text-gray-700">
-                  매장 설명
-                </label>
-                {errors.carwashDescription && (
-                  <small className="text-red-500" role="alert">
-                    {errors.carwashDescription.message}
-                  </small>
-                )}
-              </div>
-              <textarea
-                className="block p-4 bg-gray-100 border border-gray-300 outline-none resize-none h-52 w-96 rounded-xl"
-                id="carwashDescription"
-                placeholder="매장 설명"
-                {...register("carwashDescription", {
-                  required: MESSAGES.common.required,
-                })}></textarea>
-            </div>
-          </section>
-        </div>
+            <textarea
+              className="block p-4 bg-gray-100 border border-gray-300 outline-none resize-none h-52 w-96 rounded-xl"
+              id="carwashDescription"
+              defaultValue={carwashDescription}
+              placeholder="매장 설명"
+              {...register("carwashDescription", {
+                required: MESSAGES.common.required,
+              })}></textarea>
+          </div>
+        </section>
+      </div>
 
-        {/* 하단 버튼 */}
-        <div className="flex justify-center">
-          <Button type="submit" style="long">
-            입점신청
-          </Button>
-        </div>
-      </form>
-    </Box>
+      {/* 하단 버튼 */}
+      <div className="flex justify-center">
+        <Button type="submit" style="long">
+          입점신청
+        </Button>
+      </div>
+    </form>
   );
 };
 

--- a/src/components/templates/CarwashDetailEditingTemplate.jsx
+++ b/src/components/templates/CarwashDetailEditingTemplate.jsx
@@ -1,0 +1,9 @@
+const CarwashDetailEditingTemplate = () => {
+  return (
+    <div>
+      <h1>CarwashDetailEditingTemplate</h1>
+    </div>
+  );
+};
+
+export default CarwashDetailEditingTemplate;

--- a/src/components/templates/CarwashDetailEditingTemplate.jsx
+++ b/src/components/templates/CarwashDetailEditingTemplate.jsx
@@ -1,7 +1,35 @@
+import RegisterForm from "../organisms/RegisterForm";
+import Box from "../atoms/Box";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { getCarwashesDetails, putCarwashesDetails } from "../../apis/carwashes";
+
 const CarwashDetailEditingTemplate = () => {
+  const { data } = useSuspenseQuery({
+    queryKey: ["getCarwashDetail"],
+    queryFn: getCarwashesDetails,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (data) => {
+      putCarwashesDetails(data);
+    },
+  });
+
+  const carwashDetail = data.data.response;
+
   return (
-    <div>
-      <h1>CarwashDetailEditingTemplate</h1>
+    <div className="flex">
+      <Box className="grid gap-8 p-14">
+        <div className="text-2xl font-bold">세차장 정보 수정</div>
+        <RegisterForm
+          carwashName={carwashDetail.name}
+          carwashAddress={carwashDetail.location.address}
+          carwashTel={carwashDetail.tel}
+          pricePer30min={carwashDetail.price}
+          carwashDescription={carwashDetail.optime.des}
+          mutation={mutation}
+        />
+      </Box>
     </div>
   );
 };

--- a/src/components/templates/CarwashItemManagementTemplate.jsx
+++ b/src/components/templates/CarwashItemManagementTemplate.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import Card from "../molecules/Card";
 import CarwashBayItem from "../organisms/CarwashBayItem";
 import CarwashImage from "/carwashImage.png";
@@ -59,6 +60,8 @@ const CarwashItemManagementTemplate = ({
     ],
   },
 }) => {
+  const navigate = useNavigate();
+
   return (
     <div className="flex gap-16">
       <aside className="flex flex-col flex-grow-0 flex-shrink-0 gap-4">
@@ -77,6 +80,7 @@ const CarwashItemManagementTemplate = ({
           className="h-16 p-4 text-xl font-semibold text-white bg-gray-700 shadow-xl rounded-xl"
           onClick={(e) => {
             e.preventDefault();
+            navigate("/manage/item/edit");
           }}>
           세차장 정보 수정
         </button>

--- a/src/pages/CarwashDetailEditingPage.jsx
+++ b/src/pages/CarwashDetailEditingPage.jsx
@@ -1,0 +1,9 @@
+const CarwashDetailEditingPage = () => {
+  return (
+    <div>
+      <h1>CarwashDetailEditingPage</h1>
+    </div>
+  );
+};
+
+export default CarwashDetailEditingPage;

--- a/src/pages/CarwashDetailEditingPage.jsx
+++ b/src/pages/CarwashDetailEditingPage.jsx
@@ -1,8 +1,11 @@
+import { Suspense } from "react";
+import CarwashDetailEditingTemplate from "../components/templates/CarwashDetailEditingTemplate";
+
 const CarwashDetailEditingPage = () => {
   return (
-    <div>
-      <h1>CarwashDetailEditingPage</h1>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <CarwashDetailEditingTemplate />
+    </Suspense>
   );
 };
 

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -1,12 +1,28 @@
-import React from 'react';
-import RegisterForm from '../components/organisms/RegisterForm';
+import React from "react";
+import RegisterForm from "../components/organisms/RegisterForm";
+import Box from "../components/atoms/Box";
+import { useMutation } from "@tanstack/react-query";
+import { postRegister } from "../apis/carwashes";
 
 const RegisterPage = () => {
-    return (
-        <div className="w-screen h-screen flex items-center justify-center ">
-            <RegisterForm/>
+  const mutation = useMutation({
+    mutationFn: (data) => {
+      postRegister(data);
+    },
+  });
+
+  return (
+    <div className="flex items-center justify-center w-screen h-screen ">
+      <Box className="grid gap-8 p-14">
+        {/*제목 텍스트*/}
+        <div className="grid gap-4 text-center">
+          <h1 className="text-3xl font-bold">입점을 환영합니다!</h1>
+          <div className="text-gray-500">아래 정보들을 입력해주세요.</div>
         </div>
-    );
+        <RegisterForm mutation={mutation} />
+      </Box>
+    </div>
+  );
 };
 
 export default RegisterPage;


### PR DESCRIPTION
## Motivation
- 기존 RegisterForm 컴포넌트를 정보수정 페이지에 재활용하고자 했습니다.

## Key Changes
- 세차장 정보 수정 페이지 구현을 위해 파일을 새로 생성했습니다.
  - CarwashDetailEditingPage.jsx, CarwashDetailEditingTemplate.jsx 추가
- RegisterForm 컴포넌트를 재활용하기 위해 코드를 일부 수정했습니다.
  - 세차장 정보 수정 페이지에 들어갔을 때 기존 정보를 불러와 defaultValue로 지정하기 위해 정보들을 props로 받아오게 수정
  - 받아온 props를 각 TextInput의 defaultValue로 적용
  - 주간&주말 영업시간과 carwashImage, keypoint는 커스텀 컴포넌트를 사용하기 때문에 defaultValue로 적용할 수 없어 일단 제외

## To Reviewers
- 이 PR은 기능 구현보다 배포용 파일을 추가하여 배포 테스트를 위한 성격이 크니 approve 해주시면 감사하겠습니다.